### PR TITLE
fix: removed debug log spam

### DIFF
--- a/src/main/java/com/robotgryphon/compactcrafting/field/FieldHelper.java
+++ b/src/main/java/com/robotgryphon/compactcrafting/field/FieldHelper.java
@@ -26,8 +26,6 @@ public abstract class FieldHelper {
                 .map(BlockPos::immutable)
                 .toArray(BlockPos[]::new);
 
-        CompactCrafting.LOGGER.debug("Found {} nearby projectors near {}.", nearbyProjectors.length, pos);
-
         final Vector3d centerBlockChanged = Vector3d.atCenterOf(pos);
         if (nearbyProjectors.length > 0) {
             level.getCapability(CapabilityActiveWorldFields.ACTIVE_WORLD_FIELDS)


### PR DESCRIPTION
This line completely spams up servers debug logs see: 

![](https://s1.sunekaer.com/i/05-08-2021_20-34-43_Discord.png)

Simple fix, I think there is a way with forge to check if the game is in dev envs if this is needed for that.